### PR TITLE
Enable Biome rule: noUnusedImports (correctness)

### DIFF
--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -24,8 +24,6 @@
       "correctness": {
         "noUndeclaredDependencies": "error",
         "noUndeclaredVariables": "error",
-        // TODO: Re-enable noUnusedImports after fixing unused imports
-        "noUnusedImports": "off",
         // TODO: Re-enable noUnusedVariables after fixing unused variables
         "noUnusedVariables": "off",
         // TODO: Re-enable useExhaustiveDependencies after fixing hook dependencies


### PR DESCRIPTION
Enable the Biome linting rule `noUnusedImports` from the correctness category.

The rule was previously disabled in `biome.jsonc` with a TODO comment indicating it should be re-enabled after fixing unused imports.

- No violations were found in the codebase
- All 495 tests continue to pass
- Linting passes successfully across all packages

This ensures unused imports will be caught and prevented going forward, improving code quality and bundle size.

Generated with [Claude Code](https://claude.ai/code)