### PR TITLE
Enable Biome rule: noUnusedVariables (correctness)

### DIFF
--- a/frontend/apps/app/components/MarkdownContent/MarkdownContent.tsx
+++ b/frontend/apps/app/components/MarkdownContent/MarkdownContent.tsx
@@ -24,7 +24,7 @@ export const MarkdownContent: FC<MarkdownContentProps> = ({ content }) => {
       remarkPlugins={[remarkGfm]}
       components={{
         code(props: CodeProps) {
-          const { children, className, node, ...rest } = props
+          const { children, className, ...rest } = props
           const match = /language-(\w+)/.exec(className || '')
           const isInline = !match && !className
 

--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -26,8 +26,6 @@
         "noUndeclaredVariables": "error",
         // TODO: Re-enable noUnusedImports after fixing unused imports
         "noUnusedImports": "off",
-        // TODO: Re-enable noUnusedVariables after fixing unused variables
-        "noUnusedVariables": "off",
         // TODO: Re-enable useExhaustiveDependencies after fixing hook dependencies
         "useExhaustiveDependencies": "off",
         // TODO: Re-enable useImportExtensions after fixing import extensions


### PR DESCRIPTION
Enable the Biome linting rule `noUnusedVariables` from the correctness category.

The rule was previously disabled in `biome.jsonc` with a TODO comment indicating it should be re-enabled after fixing unused variables.

- Found and fixed 1 violation in MarkdownContent.tsx
- All packages now pass linting checks with the rule enabled
- Ensures unused variables are caught and prevented going forward

Generated with [Claude Code](https://claude.ai/code)