### PR TITLE
Refactor CLAUDE setup workflow to simplify script execution by changi…

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,9 +40,7 @@ jobs:
         uses: ./.github/actions/pnpm-setup
 
       - name: Setup Claude settings with lint hook
-        run: |
-          chmod +x .github/scripts/setup-claude.sh
-          ./.github/scripts/setup-claude.sh
+        run: bash .github/scripts/setup-claude.sh
 
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@6364776f60df0aeb83d4efda5906d68d8cc72137 # beta


### PR DESCRIPTION
…ng the command to use `bash` directly for improved clarity and consistency in the setup process.

## Issue

- resolve:

## Why is this change needed?
<!-- Please explain briefly why this change is necessary -->
