### PR TITLE
feat: enable Biome noImgElement rule and replace img with Next.js Image

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -6,5 +6,17 @@
         "noUndeclaredDependencies": "off"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["frontend/packages/ui/**/*"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "noImgElement": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/frontend/apps/app/features/sessions/components/SessionForm/AttachmentPreview/AttachmentPreview.tsx
+++ b/frontend/apps/app/features/sessions/components/SessionForm/AttachmentPreview/AttachmentPreview.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { RemoveButton } from '@liam-hq/ui'
+import Image from 'next/image'
 import type { FC } from 'react'
 import styles from './AttachmentPreview.module.css'
 
@@ -13,7 +14,14 @@ type Props = {
 export const AttachmentPreview: FC<Props> = ({ src, alt, onRemove }) => {
   return (
     <div className={styles.container}>
-      <img src={src} alt={alt} className={styles.image} />
+      <Image
+        src={src}
+        alt={alt}
+        width={120}
+        height={120}
+        className={styles.image}
+        style={{ objectFit: 'cover' }}
+      />
       <RemoveButton
         onClick={onRemove}
         variant="solid"

--- a/frontend/internal-packages/configs/biome.jsonc
+++ b/frontend/internal-packages/configs/biome.jsonc
@@ -34,8 +34,7 @@
         "useImportExtensions": "off"
       },
       "performance": {
-        // TODO: Re-enable noImgElement after replacing img with Next.js Image
-        "noImgElement": "off"
+        "noImgElement": "error"
       },
       "suspicious": {
         "noConsole": { "level": "error", "options": { "allow": ["warn", "error", "info", "debug"] } },

--- a/frontend/packages/ui/biome.jsonc
+++ b/frontend/packages/ui/biome.jsonc
@@ -1,4 +1,11 @@
 {
   "extends": "//",
-  "root": false
+  "root": false,
+  "linter": {
+    "rules": {
+      "performance": {
+        "noImgElement": "off"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Enable the Biome linting rule `noImgElement` from the performance category and fix violations across the codebase.

## Changes
- Enable noImgElement rule in biome.jsonc for better performance
- Replace img element with Next.js Image component in AttachmentPreview.tsx
- Configure UI package to exclude noImgElement rule (framework-agnostic library)
- Add width/height properties and objectFit for proper image optimization

## Reference
- Parent issue: #2244
- Biome rule documentation: https://biomejs.dev/linter/rules/no-img-element/

Generated with [Claude Code](https://claude.ai/code)